### PR TITLE
Add dismissible button to easy remove wp-jalali notice from admin and fixed a bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must ends with two \r.
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -34,3 +35,6 @@ Icon
 # Files that might appear on external disk
 .Spotlight-V100
 .Trashes
+
+# IDE config folder
+.idea

--- a/assets/js/admin-af.js
+++ b/assets/js/admin-af.js
@@ -138,6 +138,19 @@ jQuery(document).ready(function($) {
         },100);
     });
 
+    /**
+     * Remove notice
+     * @author Ali Irani <ali@irani.im>
+     */
+    $('.ztjalali-notice.is-dismissible').on('click', function(){
+        $.ajax({
+            url: ztjalali.ajax_url,
+            type: 'post',
+            data: {
+                action: 'ztjalali_remove_notice'
+            }
+        });
+    });
 
     /* =================================================================== */
 

--- a/assets/js/admin-ir.js
+++ b/assets/js/admin-ir.js
@@ -138,6 +138,19 @@ jQuery(document).ready(function($) {
         },100);
     });
 
+    /**
+     * Remove notice
+     * @author Ali Irani <ali@irani.im>
+     */
+    $('.ztjalali-notice.is-dismissible').on('click', function(){
+        $.ajax({
+            url: ztjalali.ajax_url,
+            type: 'post',
+            data: {
+                action: 'ztjalali_remove_notice'
+            }
+        });
+    });
 
     /* =================================================================== */
 

--- a/inc/wp-jalali-admin.php
+++ b/inc/wp-jalali-admin.php
@@ -81,6 +81,10 @@ function ztjalali_after_install_actions() {
     $active = get_option('ztjalali_do_activation');
     if ($active) {
         add_action('admin_notices', 'ztjalali_admin_message');
+        // This actions use in ajax remove notice box
+        add_action('wp_ajax_nopriv_ztjalali_remove_notice', 'ztjalali_remove_notice');
+        add_action('wp_ajax_ztjalali_remove_notice', 'ztjalali_remove_notice');
+
 //        delete_option('ztjalali_do_activation');
 //        $help_page = menu_page_url('ztjalali_help_page', FALSE);
 //        header('Location: '.$help_page);
@@ -94,8 +98,20 @@ function ztjalali_admin_message(){
                 __('WP Jalali successful installed. please check %soptions%s','ztjalali')
                 ,'<a href="'.menu_page_url('ztjalali_admin_page',FALSE).'">', '</a>'          
             );
-    echo '<div class="updated"><p>' . $Message . '</p></div>';
+    echo '<div class="updated ztjalali-notice notice is-dismissible"><p>' . $Message . '</p></div>';
 //    echo '<div class="error"><p>' . $Message . '</p></div>';
+}
+
+/**
+ * Remove admin notice with ajax and pushing dismiss button
+ * @author Ali Irani <ali@irani.im>
+ * @since 4.2
+ */
+function ztjalali_remove_notice(){
+    delete_option('ztjalali_do_activation');
+    remove_action('admin_notices', 'ztjalali_admin_message');
+    remove_action('wp_ajax_nopriv_ztjalali_remove_notice', 'ztjalali_remove_notice');
+    remove_action('wp_ajax_ztjalali_remove_notice', 'ztjalali_remove_notice');
 }
 /* =================================================================== */
 

--- a/inc/wp-jalali-admin.php
+++ b/inc/wp-jalali-admin.php
@@ -80,7 +80,7 @@ add_action('admin_init', 'ztjalali_after_install_actions');
 function ztjalali_after_install_actions() {
     $active = get_option('ztjalali_do_activation');
     if ($active) {
-        add_action('admin_notices', 'ztjalali_admin_message');
+        add_action('admin_notices', 'ztjalali_admin_message', 11);
         // This actions use in ajax remove notice box
         add_action('wp_ajax_nopriv_ztjalali_remove_notice', 'ztjalali_remove_notice');
         add_action('wp_ajax_ztjalali_remove_notice', 'ztjalali_remove_notice');
@@ -94,12 +94,13 @@ function ztjalali_after_install_actions() {
 }
 
 function ztjalali_admin_message(){
-    $Message=  sprintf(
-                __('WP Jalali successful installed. please check %soptions%s','ztjalali')
-                ,'<a href="'.menu_page_url('ztjalali_admin_page',FALSE).'">', '</a>'          
-            );
-    echo '<div class="updated ztjalali-notice notice is-dismissible"><p>' . $Message . '</p></div>';
-//    echo '<div class="error"><p>' . $Message . '</p></div>';
+    if (current_user_can('activate_plugins')) {
+        $Message=  sprintf(
+            __('WP Jalali successful installed. please check %soptions%s','ztjalali')
+            ,'<a href="'.menu_page_url('ztjalali_admin_page',FALSE).'">', '</a>'
+        );
+        echo '<div class="updated ztjalali-notice notice is-dismissible"><p>' . $Message . '</p></div>';
+    }
 }
 
 /**

--- a/wp-jalali-init.php
+++ b/wp-jalali-init.php
@@ -154,6 +154,10 @@ function ztjalali_reg_admin_css_and_js() {
         wp_enqueue_script('ztjalali_reg_admin_js', plugins_url('assets/js/admin-af.js', __FILE__), array('jquery'));
     else
         wp_enqueue_script('ztjalali_reg_admin_js', plugins_url('assets/js/admin-ir.js', __FILE__), array('jquery'));
+
+    wp_localize_script('ztjalali_reg_admin_js', 'ztjalali', array(
+        'ajax_url' => admin_url('admin-ajax.php')
+    ));
 }
 
 //theme editiong style -----------------


### PR DESCRIPTION
سلام
دو تا مشکل دیدم که فیکس کردم:
* اول نمایش آزار دهنده پیام افزونه جلالی که دائما نشون داده میشد و برای حذفش هم باید میرفتیم حتما توی صفحه افزونه تا پاک بشه. برای حل این مشکل از دکمه لغو پیام که از وردپرس ۴.۲ اضافه شده استفاده کردم و برای حذف کلی هم یک اکشن ایجکس نوشتم که این رو حذف کنه و کاری که توی رفتن به صفحه افزونه انجام میشه با زدن اون دکمه انجام بشه.
* مساله بعدی هم نمایش پیام افزونه جلالی برای تمام سطح دسترسی ها بود که این رو هم فیکس کردم که فقط برای سطح دسترسی مدیر قابل نمایش باشه

Its about "dismissible" button that added since v4.2:
* [Spinners and dismissible admin notices in 4.2](https://make.wordpress.org/core/2015/04/23/spinners-and-dismissible-admin-notices-in-4-2/)