### PR TITLE
fix same post_name for several post types

### DIFF
--- a/inc/wp-jalali-filters.php
+++ b/inc/wp-jalali-filters.php
@@ -331,7 +331,9 @@ function ztjalali_pre_get_posts_filter_fn($query) {
     if($year > 1700)
         return $query;
     if (isset($query_vars['name'])) {
-        $post_date = $wpdb->get_var($wpdb->prepare("select post_date from {$wpdb->posts} where post_name=%s order by ID", $query_vars['name']));
+        $post_queried_date = jalali_to_gregorian($year, $monthnum, $day);
+		$post_queried_date = implode( "-", $post_queried_date );
+        $post_date = $wpdb->get_var($wpdb->prepare("select post_date from {$wpdb->posts} where post_name=%s AND DATE( post_date ) = '{$post_queried_date}' order by ID", $query_vars['name']));
         $Date = explode('-', date('Y-m-d', strtotime($post_date)));
         $jDate = gregorian_to_jalali($Date[0], $Date[1], $Date[2]);
 


### PR DESCRIPTION
Fixed 404 problems caused by the same post_name for several post types.
E.g:
If you upload an attachment with the "joker" name, then post published with the same name gets not found error because of not filtered query on line 334.